### PR TITLE
fix: move ANTD_VERSION definition to version.cpp to avoid redefinition

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -7,5 +7,4 @@ extern const int ANTD_VERSION_PATCH;
 extern const char* const ANTD_VERSION_TAG;
 extern const char* const ANTD_RELEASE_NAME;
 extern const char* const ANTD_VERSION_FULL;
-
-const char* const ANTD_VERSION = "v@ANTD_VERSION_MAJOR@.@ANTD_VERSION_MINOR@.@ANTD_VERSION_PATCH@";
+extern const char* const ANTD_VERSION;


### PR DESCRIPTION
Previously, ANTD_VERSION was defined in version.h, which could lead to multiple definition errors when included in multiple translation units. This change moves the definition to version.cpp and keeps only the declaration in version.h.

- Removed definition from version.h
- Added 'extern' declaration in version.h
- Ensures single definition rule compliance