### PR TITLE
   Refactor full node list and test improvements

### DIFF
--- a/src/cryptonote_core/full_node_list.cpp
+++ b/src/cryptonote_core/full_node_list.cpp
@@ -59,7 +59,7 @@ namespace full_nodes
     return full_node_info::version_2_infinite_staking;
   }
 
-  static uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister, uint64_t n)
+  uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister, uint64_t n)
   {
     uint64_t secureMax = mersenne_twister.max() - mersenne_twister.max() % n;
     uint64_t x;
@@ -559,22 +559,19 @@ namespace full_nodes
     calc_swarm_changes(existing_swarms, seed);
 
     /// Apply changes
-    for (const auto entry : existing_swarms) {
+  for (const auto& entry : existing_swarms) {
+  const swarm_id_t swarm_id = entry.first;
+  const std::vector<crypto::public_key>& snodes = entry.second;
 
-      const swarm_id_t swarm_id = entry.first;
-      const std::vector<crypto::public_key>& snodes = entry.second;
+  for (const auto& snode : snodes) {
+    auto& sn_info = m_transient_state.full_nodes_infos.at(snode);
+    if (sn_info.swarm_id == swarm_id) continue;
 
-      for (const auto snode : snodes) {
-
-        auto& sn_info = m_transient_state.full_nodes_infos.at(snode);
-        if (sn_info.swarm_id == swarm_id) continue; /// nothing changed for this snode
-
-        /// modify info and record the change
-        m_transient_state.rollback_events.push_back(std::unique_ptr<rollback_event>(new rollback_change(height, snode, sn_info)));
-        sn_info.swarm_id = swarm_id;
-      }
-
+    m_transient_state.rollback_events.push_back(
+        std::unique_ptr<rollback_event>(new rollback_change(height, snode, sn_info)));
+    sn_info.swarm_id = swarm_id;
     }
+   }
   }
 
   static bool get_contribution(cryptonote::network_type nettype, int hard_fork_version, const cryptonote::transaction& tx, uint64_t block_height, parsed_tx_contribution &parsed_contribution)
@@ -1452,19 +1449,6 @@ namespace full_nodes
     }
 
     return true;
-  }
-
-  template<typename T>
-  void antd_shuffle(std::vector<T>& a, uint64_t seed)
-  {
-    if (a.size() <= 1) return;
-    std::mt19937_64 mersenne_twister(seed);
-    for (size_t i = 1; i < a.size(); i++)
-    {
-      size_t j = (size_t)uniform_distribution_portable(mersenne_twister, i+1);
-      if (i != j)
-        std::swap(a[i], a[j]);
-    }
   }
 
   void full_node_list::store_quorum_state_from_rewards_list(uint64_t height)

--- a/src/cryptonote_core/full_node_list.h
+++ b/src/cryptonote_core/full_node_list.h
@@ -166,8 +166,20 @@ namespace full_nodes
     END_SERIALIZE()
   };
 
+  uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister, uint64_t n);
+
   template<typename T>
-  void antd_shuffle(std::vector<T>& a, uint64_t seed);
+  void antd_shuffle(std::vector<T>& a, uint64_t seed)
+  {
+    if (a.size() <= 1) return;
+    std::mt19937_64 mersenne_twister(seed);
+    for (size_t i = 1; i < a.size(); i++)
+    {
+      size_t j = (size_t)uniform_distribution_portable(mersenne_twister, i+1);
+      if (i != j)
+        std::swap(a[i], a[j]);
+    }
+  }
 
   class full_node_list
     : public cryptonote::Blockchain::BlockAddedHook,

--- a/tests/core_proxy/core_proxy.cpp
+++ b/tests/core_proxy/core_proxy.cpp
@@ -197,6 +197,33 @@ bool tests::proxy_core::handle_incoming_txs(const std::vector<blobdata>& tx_blob
     return true;
 }
 
+bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_blob,
+                                              cryptonote::block* b,
+                                              cryptonote::block_verification_context& bvc,
+                                              bool update_miner_blocktemplate)
+{
+  block parsed_block = AUTO_VAL_INIT(parsed_block);
+
+  if (!parse_and_validate_block_from_blob(block_blob, parsed_block)) {
+    std::cerr << "Failed to parse and validate block blob (ptr version)" << std::endl;
+    bvc.m_verifivation_failed = true;
+    return false;
+  }
+
+  if (b != nullptr)
+    *b = parsed_block;
+
+   crypto::hash h = get_block_hash(parsed_block);
+  crypto::hash lh = get_block_longhash(nullptr, parsed_block, 0, 0);
+
+  if (!add_block(h, lh, parsed_block, block_blob)) {
+    bvc.m_verifivation_failed = true;
+    return false;
+  }
+
+  bvc.m_verifivation_failed = false;
+  return true;
+}
 bool tests::proxy_core::handle_incoming_block(const cryptonote::blobdata& block_blob, cryptonote::block_verification_context& bvc, bool update_miner_blocktemplate) {
     block b = AUTO_VAL_INIT(b);
 

--- a/tests/core_proxy/core_proxy.h
+++ b/tests/core_proxy/core_proxy.h
@@ -88,6 +88,7 @@ namespace tests
     cryptonote::Blockchain &get_blockchain_storage() { throw std::runtime_error("Called invalid member function: please never call get_blockchain_storage on the TESTING class proxy_core."); }
     bool get_test_drop_download() {return true;}
     bool get_test_drop_download_height() {return true;}
+    bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks_entry, std::vector<cryptonote::block> &blocks) { return true; }
     bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry>  &blocks) { return true; }
     bool cleanup_handle_incoming_blocks(bool force_sync = false) { return true; }
     uint64_t get_target_blockchain_height() const { return 1; }
@@ -99,6 +100,10 @@ namespace tests
     bool get_blocks(uint64_t start_offset, size_t count, std::vector<std::pair<cryptonote::blobdata, cryptonote::block>>& blocks, std::vector<cryptonote::blobdata>& txs) const { return false; }
     bool get_transactions(const std::vector<crypto::hash>& txs_ids, std::vector<cryptonote::transaction>& txs, std::vector<crypto::hash>& missed_txs) const { return false; }
     bool get_block_by_hash(const crypto::hash &h, cryptonote::block &blk, bool *orphan = NULL) const { return false; }
+    bool handle_incoming_block(const cryptonote::blobdata& block_blob,
+                           cryptonote::block* b,
+                           cryptonote::block_verification_context& bvc,
+                           bool update_miner_blocktemplate);
     uint8_t get_ideal_hard_fork_version() const { return 0; }
     uint8_t get_ideal_hard_fork_version(uint64_t height) const { return 0; }
     uint8_t get_hard_fork_version(uint64_t height) const { return 0; }

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -43,7 +43,7 @@
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/constants.h"
 #include "cryptonote_basic/miner.h"
-
+#include "cryptonote_core/full_node_list.h"
 #include "chaingen.h"
 #include "device/device.hpp"
 using namespace std;

--- a/tests/unit_tests/ban.cpp
+++ b/tests/unit_tests/ban.cpp
@@ -58,6 +58,34 @@ public:
   bool handle_incoming_txs(const std::vector<cryptonote::blobdata>& tx_blob, std::vector<cryptonote::tx_verification_context>& tvc, bool keeped_by_block, bool relayed, bool do_not_relay) { return true; }
   bool handle_incoming_block(const cryptonote::blobdata& block_blob, cryptonote::block_verification_context& bvc, bool update_miner_blocktemplate = true) { return true; }
   bool handle_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) { return false; }
+  bool handle_incoming_block(const cryptonote::blobdata& block_blob,
+                           cryptonote::block* b,
+                           cryptonote::block_verification_context& bvc,
+                           bool update_miner_blocktemplate)
+{
+  if (b != nullptr)
+  {
+    cryptonote::block parsed_block;
+    if (!cryptonote::parse_and_validate_block_from_blob(block_blob, parsed_block))
+    {
+      bvc.m_verifivation_failed = true;
+      return false;
+    }
+    *b = parsed_block;
+  }
+
+  bvc.m_verifivation_failed = false;
+  return true;
+}
+
+bool prepare_handle_incoming_blocks(const std::vector<cryptonote::block_complete_entry> &blocks_entry,
+                                    std::vector<cryptonote::block> &blocks)
+{
+
+  blocks.resize(blocks_entry.size());
+  return true;
+}
+
   void pause_mine(){}
   void resume_mine(){}
   bool on_idle(){return true;}


### PR DESCRIPTION
    - Made uniform_distribution_portable non-static and moved declaration to header
    - Moved antd_shuffle implementation to header file
    - Improved const correctness in swarm iteration (using const&)
    - Fixed indentation in swarm changes application loop
    - Added missing handle_incoming_block implementation in test core proxy
    - Added prepare_handle_incoming_blocks with blocks vector parameter
    - Added cryptonote_core/full_node_list.h include in chaingen.cpp
    - Added test implementations for handle_incoming_block and prepare_handle_incoming_blocks in ban.cpp unit tests